### PR TITLE
Better Elixir Support

### DIFF
--- a/themes/sunset-theme.json
+++ b/themes/sunset-theme.json
@@ -117,7 +117,11 @@
 			}
 		},
 		{
-			"scope": "constant.language",
+			"scope": [
+				"constant.language", 
+				"constant.character",
+				"constant.other"
+			],
 			"settings": {
 				"foreground": "#eac66c"
 			}


### PR DESCRIPTION
This commit adds rules for `constant.character` and `constant.other`, which are used to mark certain parts of code in Elixir files.  I chose to default these rules to use the same color as `constant.language` (i.e. "#eac66c"), the result is quite nice :)

#### Before
![image](https://user-images.githubusercontent.com/518153/45277119-3b6da100-b494-11e8-9f3e-f2dd0f6eb5cd.png)


#### After
![image](https://user-images.githubusercontent.com/518153/45277102-14af6a80-b494-11e8-9b6e-a415f6d9f6cb.png)
